### PR TITLE
Use build arg to build Windows image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG node=node:8.7-alpine
+
 # Build frontend
-FROM node:8.7-alpine as frontend
+FROM $node as frontend
 WORKDIR /app
 COPY client/package.json .
 RUN npm install
@@ -7,7 +9,7 @@ COPY client/ .
 RUN npm run build
 
 # Build backend
-FROM node:8.7-alpine as backend
+FROM $node as backend
 WORKDIR /app
 COPY api/package.json .
 RUN npm install
@@ -15,7 +17,7 @@ COPY api/ .
 RUN npm run build
 
 # Put them together
-FROM node:8.7-alpine
+FROM $node
 EXPOSE 3000
 WORKDIR /app
 COPY api/package.json .

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is serving as an updated version of the Swarm Visualizer found at h
 
 ## Running the visualizer
 
-###
+### Linux/Mac
 
 Running as container:
 
@@ -28,6 +28,15 @@ docker container run \
   mikesir87/swarm-viz
 ```
 
+### Windows Server 1709
+
+```
+docker container run \
+  --name swarm-viz \
+  -p 3000:3000 \
+  -v //./pipe/docker_engine://./pipe/docker_engine \
+  mikesir87/swarm-viz
+```
 
 ## Development
 
@@ -39,4 +48,12 @@ docker-compose up -d
 
 The backend (api) is found in the `/api` directory and the frontend is found in the `/client` directory.
 
+## Build
 
+### Windows
+
+At the moment there is no official node image for Windows. Therefore apply another base image to build the app.
+
+```
+docker build -t mikesir87/swarm-viz --build-arg node=stefanscherer/node-windows:1709 .
+```

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ docker container run \
 
 ### Windows Server 1709
 
+Run as Windows container:
+
 ```
-docker container run \
-  --name swarm-viz \
-  -p 3000:3000 \
-  -v //./pipe/docker_engine://./pipe/docker_engine \
+docker container run `
+  --name swarm-viz `
+  -p 3000:3000 `
+  -u ContainerAdministrator `
+  -v //./pipe/docker_engine://./pipe/docker_engine `
   mikesir87/swarm-viz
 ```
 


### PR DESCRIPTION
I've added an `ARG` to specify a different base image for the multi-stage build. So it's easy on Windows Server 1709 or Windows 10 Fall Creators Update to build a Windows image for it.

Build it:

```
docker build -t mikesir87/swarm-viz --build-arg node=stefanscherer/node-windows:1709 .
```


Run it:

```
docker run -d -p 3000:3000 -v //./pipe/docker_engine://./pipe/docker_engine -u ContainerAdministrator mikesir87/swarm-viz
```