### PR TITLE
Add target build ARG for cross builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG node=node:8.7-alpine
+ARG target=node:8.7-alpine
 
 # Build frontend
 FROM $node as frontend
@@ -17,11 +18,14 @@ COPY api/ .
 RUN npm run build
 
 # Put them together
-FROM $node
-EXPOSE 3000
+FROM $node as proddeps
 WORKDIR /app
 COPY api/package.json .
 RUN npm install --production
 COPY --from=backend /app/dist /app/dist
 COPY --from=frontend /app/build /app/build
+
+FROM $target
+EXPOSE 3000
+COPY --from=proddeps /app /app
 CMD node /app/dist/index.js


### PR DESCRIPTION
Add another build ARG to allow cross builds. We tested this at the DockerCaptain hack day on IBM s390.

```
docker build -t stefanscherer/swarm-vis:s390 --build-arg target=s390x/node:8.7 .
```
