### PR TITLE
Add label parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ A label starting with `swarm-viz.link.` will use any remaining text in the ident
 Input          |          Output
 ---------------|-----------------
 ${containerid} | The container's unique id string.
-${imagename}   | The name of the image the container was made with. It is pulled from the label `com.docker.stack.image`.
-${stackname}   | The name of the stack the container is a part of. It is pulled from the label `com.docker.stack.namespace`.
+${imagename}   | The name of the image the container was made with. It is found by removing the extra info from the container name.
+${stackname}   | The name of the stack the container is a part of. It is found from subtracting the image name from the service name.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ docker build -t mikesir87/swarm-viz --build-arg node=stefanscherer/node-windows:
 
 ## Label Parsing
 
-Swarm-viz will read through parse labels beginning with `swarm-viz.` and display them in an "Extra Info" section.
+Swarm-viz will parse labels beginning with `swarm-viz.` and display them in an "Extra Info" section. It also supports templating.
 
 ### Link handling
 
 A label starting with `swarm-viz.link.` will use any remaining text in the identifier as a label, and will turn the value of the label into a clickable link. (Example: `swarm-viz.link.foo:http://google.com` will create the entry `foo : http://google.com`.)
+
+Templating is taken into account before link parsing, allowing for dynamic links.
 
 ### Templating
 

--- a/README.md
+++ b/README.md
@@ -60,3 +60,19 @@ At the moment there is no official node image for Windows. Therefore apply anoth
 ```
 docker build -t mikesir87/swarm-viz --build-arg node=stefanscherer/node-windows:1709 .
 ```
+
+## Label Parsing
+
+Swarm-viz will read through parse labels beginning with `swarm-viz.` and display them in an "Extra Info" section.
+
+### Link handling
+
+A label starting with `swarm-viz.link.` will use any remaining text in the identifier as a label, and will turn the value of the label into a clickable link. (Example: `swarm-viz.link.foo:http://google.com` will create the entry `foo : http://google.com`.)
+
+### Templating
+
+Input          |          Output
+---------------|-----------------
+${containerid} | The container's unique id string.
+${imagename}   | The name of the image the container was made with. It is pulled from the label `com.docker.stack.image`.
+${stackname}   | The name of the stack the container is a part of. It is pulled from the label `com.docker.stack.namespace`.

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -11,7 +11,7 @@ function ParseLabelOutput(props){
   
   if(props.keyLabel.indexOf("swarm-viz.link.")===0){
     return(
-      <FormRow label={props.keyLabel.slice(-((props.keyLabel.length-1)-(props.keyLabel.lastIndexOf("."))))}>
+      <FormRow label={props.keyLabel.slice(15)}>
         <a href={keyValue}> {keyValue} </a>
       </FormRow>
     )

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -29,7 +29,7 @@ class SwarmVizLabelParser extends React.Component {
   render(){
     const { task, service } = this.props;
     var toBeParsed = Object.keys(service.Spec.Labels).filter(function(label){
-      return label.indexOf("swarm-viz.")>=0;
+      return label.indexOf("swarm-viz.")===0;
     })
     return(
       <div>

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -9,7 +9,7 @@ function ParseLabelOutput(props){
   keyValue=keyValue.replace("${imagename}", props.imageName);
   keyValue=keyValue.replace("${stackname}", props.nameSpace);
   
-  if(props.keyLabel.indexOf("swarm-viz.link.")>=0){
+  if(props.keyLabel.indexOf("swarm-viz.link.")===0){
     return(
       <FormRow label={props.keyLabel.slice(-((props.keyLabel.length-1)-(props.keyLabel.lastIndexOf("."))))}>
         <a href={keyValue}> {keyValue} </a>

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -5,6 +5,7 @@ import actions from "../../actions";
 
 
 function ParseLabelOutput(props){
+    console.log(props.imageName)
   var keyValue=props.keyValue.replace("${containerid}", props.containerId);
   keyValue=keyValue.replace("${imagename}", props.imageName);
   keyValue=keyValue.replace("${stackname}", props.nameSpace);
@@ -38,7 +39,10 @@ class SwarmVizLabelParser extends React.Component {
             <hr />
             <h3>Extra Info</h3>
               { toBeParsed.map((key) => (
-                <div key={key}><ParseLabelOutput keyLabel={key} keyValue={ service.Spec.Labels[key] } containerId={task.Status.ContainerStatus.ContainerID} imageName={service.Spec.Labels["com.docker.stack.image"]} nameSpace={service.Spec.Labels["com.docker.stack.namespace"]}/></div>
+                <div key={key}><ParseLabelOutput keyLabel={key} keyValue={ service.Spec.Labels[key] } 
+                    containerId={task.Status.ContainerStatus.ContainerID}
+                    imageName={task.Spec.ContainerSpec.Image.slice(0,-(task.Spec.ContainerSpec.Image.length)+(task.Spec.ContainerSpec.Image.indexOf(":")))}/>
+                </div>
               ))}
           </span>
         )}

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import {connect} from "react-redux";
+import FormRow from "./FormRow";
+import actions from "../../actions";
+
+
+function ParseLabelOutput(props){
+  var keyValue=props.keyValue.replace("${containerid}", props.containerId);
+  keyValue=keyValue.replace("${imagename}", props.imageName);
+  keyValue=keyValue.replace("${stackname}", props.nameSpace);
+  
+  if(props.keyLabel.indexOf("swarm-viz.link.")>=0){
+    return(
+      <FormRow label={props.keyLabel.slice(-((props.keyLabel.length-1)-(props.keyLabel.lastIndexOf("."))))}>
+        <a href={keyValue}> {keyValue} </a>
+      </FormRow>
+    )
+  }
+  //Slicing off the "swarm-viz." to look neater
+  var keyLabel=props.keyLabel.slice(10);
+  return(
+    <FormRow label={keyLabel}>
+      {keyValue}
+    </FormRow>
+  )
+}
+
+class SwarmVizLabelParser extends React.Component {
+  render(){
+    const { task, service } = this.props;
+    var toBeParsed = Object.keys(service.Spec.Labels).filter(function(label){
+      return label.indexOf("swarm-viz.")>=0;
+    })
+    return(
+      <div>
+        { toBeParsed.length>= 1 && (
+          <span>
+            <hr />
+            <h3>Extra Info</h3>
+              { toBeParsed.map((key) => (
+                <div key={key}><ParseLabelOutput keyLabel={key} keyValue={ service.Spec.Labels[key] } containerId={task.Status.ContainerStatus.ContainerID} imageName={service.Spec.Labels["com.docker.stack.image"]} nameSpace={service.Spec.Labels["com.docker.stack.namespace"]}/></div>
+              ))}
+          </span>
+        )}
+      </div>
+    )
+  }
+}
+const mapStateToProps = (state, props) => ({
+  task : state.swarmState.tasks.filter((task) => task.ID === props.taskId)[0],
+  service : state.swarmState.services.find((service) => service.ID === props.serviceId),
+});
+export default connect(mapStateToProps, actions)(SwarmVizLabelParser);

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -5,10 +5,9 @@ import actions from "../../actions";
 
 
 function ParseLabelOutput(props){
-    console.log(props.imageName)
   var keyValue=props.keyValue.replace("${containerid}", props.containerId);
   keyValue=keyValue.replace("${imagename}", props.imageName);
-  keyValue=keyValue.replace("${stackname}", props.nameSpace);
+  keyValue=keyValue.replace("${stackname}", props.serviceName.slice(0,(props.serviceName.indexOf(props.imageName)-(props.serviceName.length + 1))));
   
   if(props.keyLabel.indexOf("swarm-viz.link.")===0){
     return(
@@ -42,7 +41,7 @@ class SwarmVizLabelParser extends React.Component {
                 <div key={key}><ParseLabelOutput keyLabel={key} keyValue={ service.Spec.Labels[key] } 
                     containerId={task.Status.ContainerStatus.ContainerID}
                     imageName={task.Spec.ContainerSpec.Image.slice(0,-(task.Spec.ContainerSpec.Image.length)+(task.Spec.ContainerSpec.Image.indexOf(":")))}
-                    nameSpace={service.Spec.Labels["com.docker.stack.namespace"]}/>
+                    serviceName={service.Spec.Name}/>
                 </div>
               ))}
           </span>

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -41,7 +41,8 @@ class SwarmVizLabelParser extends React.Component {
               { toBeParsed.map((key) => (
                 <div key={key}><ParseLabelOutput keyLabel={key} keyValue={ service.Spec.Labels[key] } 
                     containerId={task.Status.ContainerStatus.ContainerID}
-                    imageName={task.Spec.ContainerSpec.Image.slice(0,-(task.Spec.ContainerSpec.Image.length)+(task.Spec.ContainerSpec.Image.indexOf(":")))}/>
+                    imageName={task.Spec.ContainerSpec.Image.slice(0,-(task.Spec.ContainerSpec.Image.length)+(task.Spec.ContainerSpec.Image.indexOf(":")))}
+                    nameSpace={service.Spec.Labels["com.docker.stack.namespace"]}/>
                 </div>
               ))}
           </span>

--- a/client/src/components/nodes/SwarmVizLabelParser.jsx
+++ b/client/src/components/nodes/SwarmVizLabelParser.jsx
@@ -35,8 +35,7 @@ class SwarmVizLabelParser extends React.Component {
       <div>
         { toBeParsed.length>= 1 && (
           <span>
-            <hr />
-            <h3>Extra Info</h3>
+            <h3>Parsed Info</h3>
               { toBeParsed.map((key) => (
                 <div key={key}><ParseLabelOutput keyLabel={key} keyValue={ service.Spec.Labels[key] } 
                     containerId={task.Status.ContainerStatus.ContainerID}
@@ -44,6 +43,7 @@ class SwarmVizLabelParser extends React.Component {
                     serviceName={service.Spec.Name}/>
                 </div>
               ))}
+            <hr />
           </span>
         )}
       </div>

--- a/client/src/components/nodes/TaskInfoModal.jsx
+++ b/client/src/components/nodes/TaskInfoModal.jsx
@@ -3,6 +3,7 @@ import Modal from "react-bootstrap/es/Modal";
 import Button from "react-bootstrap/es/Button";
 import {connect} from "react-redux";
 import FormRow from "./FormRow";
+import SwarmVizLabelParser from "./SwarmVizLabelParser";
 import ServiceDetails from "./ServiceDetails";
 import actions from "../../actions";
 
@@ -29,6 +30,8 @@ class TaskInfoModal extends React.Component {
               <FormRow label="Updated At">
                 { task.UpdatedAt }
               </FormRow>
+
+              <SwarmVizLabelParser taskId={this.props.taskId} serviceId={ task.ServiceID } />
 
               <hr />
               <h3>Service Details</h3>

--- a/client/src/components/nodes/TaskInfoModal.jsx
+++ b/client/src/components/nodes/TaskInfoModal.jsx
@@ -17,6 +17,9 @@ class TaskInfoModal extends React.Component {
           </Modal.Header>
           <Modal.Body>
             <form className="form-horizontal">
+
+              <SwarmVizLabelParser taskId={this.props.taskId} serviceId={ task.ServiceID } />
+              
               <h3>Container Details</h3>
               <FormRow label="Container ID">
                 { task.Status.ContainerStatus.ContainerID }
@@ -30,8 +33,6 @@ class TaskInfoModal extends React.Component {
               <FormRow label="Updated At">
                 { task.UpdatedAt }
               </FormRow>
-
-              <SwarmVizLabelParser taskId={this.props.taskId} serviceId={ task.ServiceID } />
 
               <hr />
               <h3>Service Details</h3>


### PR DESCRIPTION
The motivation behind this change is to allow automation to create easy to find and useful info/links about containers.

A use case would be if you wanted to automatically generate a link to the container's log file, you could assign the label `swarm-viz.link.log=https://log.storage.site/${imagename}/${containerid}` to a service and easily find the log location when looking at the details of any container belonging to the service. 
This is particularly useful in large swarms with lots of container replication.

Any labels that were parsed will be shown at the top of the detailed info screen, but if no labels start with `swarm-viz.` then the section will not render, leaving the page looking exactly how it is now.
