### PR TITLE
changing CMD to exec mode, adding SIGTERM/INT handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=frontend /app/build /app/build
 FROM $target
 EXPOSE 3000
 COPY --from=proddeps /app /app
-CMD node /app/dist/index.js
+CMD ["node", "/app/dist/index.js"]

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -27,3 +27,26 @@ app.get("/api/tasks", async(req, res) => {
 });
 
 app.listen(3000, () => console.log("App listening on port 3000"));
+
+//
+// need this in docker container to properly exit since node doesn't handle 
+// SIGINT/SIGTERM
+// Note, a more graceful way would be first server.close(), wait X seconds for 
+// connections to close (but websockets), then process.exit()
+//
+
+process
+  .on('SIGTERM', shutdown('SIGTERM')) // docker stop
+  .on('SIGINT', shutdown('SIGINT')) // ctrl-c in linux/mac
+  .on('uncaughtException', shutdown('uncaughtException'));
+
+// shut down server without waiting
+function shutdown(signal) {
+  return (err) => {
+    console.log(`${ signal }...`);
+    if (err) console.error(err.stack || err);
+    setTimeout(() => {
+      process.exit(err ? 1 : 0);
+    }, 0).unref();
+  };
+}


### PR DESCRIPTION
Changed Dockerfile CMD to the preferred `exec` form so node isn't run in a shell.

Added SIGTERM and SIGINT handling so docker doesn't hang during `ctrl-c` and `docker stop`.

Also, Here's good background on the [node signal handling problem](https://kb.heroku.com/why-does-sigterm-handling-not-work-correctly-in-nodejs-with-npm) and a [more graceful way to do it](https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately) if you want to wait for clients to close connections.