### PR TITLE
Update regex to allow private repositories and global services

### DIFF
--- a/client/src/components/nodes/ImageName.jsx
+++ b/client/src/components/nodes/ImageName.jsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const IMAGE_PARSE_REGEX = /^(.*?):(.*?)@sha256:(.*)/;
+const IMAGE_PARSE_REGEX = /^(.+):(.*?)(?:@sha256)?:(.*)/;
 
 class ImageName extends React.Component {
   render() {

--- a/client/src/components/nodes/ServiceDetails.jsx
+++ b/client/src/components/nodes/ServiceDetails.jsx
@@ -14,7 +14,12 @@ class ServiceDetails extends React.Component {
             { service.Spec.Name }
           </FormRow>
           <FormRow label="Replicas">
-            { service.Spec.Mode.Replicated.Replicas }
+            { service.Spec.Mode.Replicated && (
+              service.Spec.Mode.Replicated.Replicas
+            )}
+            { service.Spec.Mode.Global && (
+              "Global"
+            )}
           </FormRow>
           { service.Spec.EndpointSpec.Ports && (
             <FormRow label="Ports">


### PR DESCRIPTION
Allows private repositories with ports in url e.g.:
repo.company.com:portno/image/name:version

Global services would fail when clicked